### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Fontstand BV/Fontstand.pkg.recipe
+++ b/Fontstand BV/Fontstand.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.paul-cossey.pkg.Fontstand</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.fontstand-bv.mac.Fontstand</string>
 		<key>NAME</key>
 		<string>Fontstand</string>
 	</dict>

--- a/toketaWare ltd/iThoughtsX.pkg.recipe
+++ b/toketaWare ltd/iThoughtsX.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.paul-cossey.pkg.iThoughtsX</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.toketaware.ithoughtsx</string>
 		<key>NAME</key>
 		<string>iThoughtsX</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Fontstand BV/Fontstand.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/paul-cossey-recipes/Fontstand\ BV/Fontstand.pkg.recipe
Processing repos/paul-cossey-recipes/Fontstand BV/Fontstand.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Fontstand.tgz',
           'url': 'https://fontstand.com/application/download/61'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 27 Nov 2019 21:17:21 GMT
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/downloads/Fontstand.tgz
{'Output': {'download_changed': True,
            'last_modified': 'Wed, 27 Nov 2019 21:17:21 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/downloads/Fontstand.tgz',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/downloads/Fontstand.tgz'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/downloads/Fontstand.tgz',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/Fontstand',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'tar_gzip' from filename Fontstand.tgz
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/downloads/Fontstand.tgz to ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/Fontstand
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/Fontstand/Fontstand.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.fontstand-bv.mac.Fontstand" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = CF7GPVF5J6)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/Fontstand/Fontstand.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/Fontstand/Fontstand.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/Fontstand/Fontstand.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/Fontstand/Fontstand.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 2.2.7 in file ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/Fontstand/Fontstand.app/Contents/Info.plist
{'Output': {'version': '2.2.7'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/Fontstand/Fontstand.app',
           'version': '2.2.7'}}
AppPkgCreator: BundleID: com.fontstand-bv.mac.Fontstand
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/Fontstand/Fontstand.app to ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/payload/Applications/Fontstand.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.fontstand-bv.mac.Fontstand',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/Fontstand-2.2.7.pkg',
                                                        'version': '2.2.7'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.2.7'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/receipts/Fontstand.pkg-receipt-20210213-234645.plist

The following new items were downloaded:
    Download Path                                                                                      
    -------------                                                                                      
    ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/downloads/Fontstand.tgz  

The following packages were built:
    Identifier                      Version  Pkg Path                                                                                       
    ----------                      -------  --------                                                                                       
    com.fontstand-bv.mac.Fontstand  2.2.7    ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.Fontstand/Fontstand-2.2.7.pkg  
```

## ❌ toketaWare ltd/iThoughtsX.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/paul-cossey-recipes/toketaWare\ ltd/iThoughtsX.pkg.recipe
Processing repos/paul-cossey-recipes/toketaWare ltd/iThoughtsX.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://s3-eu-west-1.amazonaws.com/ithoughtsx/ithoughtsx.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 5.25
SparkleUpdateInfoProvider: Found URL https://cdn.toketaware.com?download=iThoughtsX_5_25.zip
{'Output': {'url': 'https://cdn.toketaware.com?download=iThoughtsX_5_25.zip',
            'version': '5.25'}}
URLDownloader
{'Input': {'filename': 'iThoughtsX-5.25.zip',
           'url': 'https://cdn.toketaware.com?download=iThoughtsX_5_25.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
Receipt written to ~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.iThoughtsX/receipts/iThoughtsX.pkg-receipt-20210213-234649.plist

The following recipes failed:
    repos/paul-cossey-recipes/toketaWare ltd/iThoughtsX.pkg.recipe
        Error in com.github.paul-cossey.pkg.iThoughtsX: Processor: URLDownloader: Error: Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://cdn.toketaware.com?download=iThoughtsX_5_25.zip', '--fail', '--output', '~/Library/AutoPkg/Cache/com.github.paul-cossey.pkg.iThoughtsX/downloads/tmp2na1u4vp']' returned non-zero exit status 22.

Nothing downloaded, packaged or imported.
```

