### PR TITLE
Remove DISABLE_CODE_SIGNATURE_VERIFICATION input variable

### DIFF
--- a/Fontstand BV/Fontstand.munki.recipe
+++ b/Fontstand BV/Fontstand.munki.recipe
@@ -14,8 +14,6 @@
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>Fontstand</string>
-		<key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
-        	<string>True</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>


### PR DESCRIPTION
There's no CodeSignatureVerifier processor in this recipe, so this input variable has no effect.