### PR TITLE
Update Support-pkg.download.recipe

### DIFF
--- a/Support/Support-pkg.download.recipe
+++ b/Support/Support-pkg.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>asset_regex</key>
-                <string>.*\.pkg</string>
+                <string>Support\..*\.pkg</string>
                 <key>github_repo</key>
                 <string>root3nl/SupportApp</string>
             </dict>


### PR DESCRIPTION
Fixes the regex to download the correct package.

Currently the recipe is downloading `SupportHelper1.0.pkg` instead of `Support.2.5.1.pkg`.

> Looking for com.github.paul-cossey.download.Support-pkg...
Found com.github.paul-cossey.download.Support-pkg in recipe map
**load_recipe time: 0.00034550000418676063
Processing com.github.paul-cossey.download.Support-pkg...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*\\.pkg', 'github_repo': 'root3nl/SupportApp'}}
GitHubReleasesInfoProvider: Matched regex '.*\.pkg' among asset(s): Support.2.5.1.pkg
GitHubReleasesInfoProvider: Matched regex '.*\.pkg' among asset(s): SupportHelper1.0.pkg
GitHubReleasesInfoProvider: Selected asset 'SupportHelper1.0.pkg' from tag 'v2.5.1' at url https://github.com/root3nl/SupportApp/releases/download/v2.5.1/SupportHelper1.0.pkg

With this change it now downloads the correct package:

> Looking for com.github.paul-cossey.download.Support-pkg.test...
Found com.github.paul-cossey.download.Support-pkg.test in recipe map
**load_recipe time: 1.7772222499988857
Processing com.github.paul-cossey.download.Support-pkg.test...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Support\\..*\\.pkg',
           'github_repo': 'root3nl/SupportApp'}}
GitHubReleasesInfoProvider: Matched regex 'Support\..*\.pkg' among asset(s): Support.2.5.1.pkg
GitHubReleasesInfoProvider: Selected asset 'Support.2.5.1.pkg' from tag 'v2.5.1' at url https://github.com/root3nl/SupportApp/releases/download/v2.5.1/Support.2.5.1.pkg

I think this will work longterm based on how these packages have been named historically, but I am open to something better if it exists.