### PR TITLE
Update download pattern and file paths in Mural recipes

### DIFF
--- a/MURAL/MURAL.download.recipe
+++ b/MURAL/MURAL.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href=\"https://download\.mural\.co/mac-app/MURAL-(([0-9]+(\.[0-9]+)+))\.dmg\"</string>
+                <string>href="https://download.mural.co/mac-app/Mural-([\d\.]+).dmg"</string>
                 <key>result_output_var_name</key>
                 <string>version</string>
                 <key>url</key>
@@ -36,7 +36,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://download.mural.co/mac-app/MURAL-%version%.dmg</string>
+                <string>https://download.mural.co/mac-app/Mural-%version%.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -49,7 +49,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/MURAL.app</string>
+                <string>%pathname%/Mural.app</string>
                 <key>requirement</key>
                 <string>identifier "co.mural.macOS" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "823N8XU8B8"</string>
             </dict>
@@ -60,7 +60,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pathname%/MURAL.app/Contents/Info.plist</string>
+                <string>%pathname%/Mural.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>

--- a/MURAL/MURAL.install.recipe
+++ b/MURAL/MURAL.install.recipe
@@ -30,7 +30,7 @@
                         <key>destination_path</key>
                         <string>/Applications</string>
                         <key>source_item</key>
-                        <string>MURAL.app</string>
+                        <string>Mural.app</string>
                     </dict>
                 </array>
             </dict>


### PR DESCRIPTION
This PR updates the Mural recipes with new pattern for matching the download link, and updates file paths to match the title-cased app name.

Verbose recipe run output:

```
% autopkg run -vvq 'MURAL/MURAL.download.recipe'
Processing MURAL/MURAL.download.recipe...
WARNING: MURAL/MURAL.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="https://download.mural.co/mac-app/Mural-([\\d\\.]+).dmg"',
           'result_output_var_name': 'version',
           'url': 'https://www.mural.co/apps'}}
URLTextSearcher: Found matching text (version): 2.0.0
{'Output': {'version': '2.0.0'}}
URLDownloader
{'Input': {'filename': 'MURAL.dmg',
           'url': 'https://download.mural.co/mac-app/Mural-2.0.0.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 06 Dec 2022 19:19:19 GMT
URLDownloader: Storing new ETag header: 0x8DAD7BEC644E3E1
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.paul-cossey.download.MURAL/downloads/MURAL.dmg
{'Output': {'download_changed': True,
            'etag': '0x8DAD7BEC644E3E1',
            'last_modified': 'Tue, 06 Dec 2022 19:19:19 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.paul-cossey.download.MURAL/downloads/MURAL.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.paul-cossey.download.MURAL/downloads/MURAL.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.paul-cossey.download.MURAL/downloads/MURAL.dmg/Mural.app',
           'requirement': 'identifier "co.mural.macOS" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"823N8XU8B8"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.paul-cossey.download.MURAL/downloads/MURAL.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.I1wxXd/Mural.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.I1wxXd/Mural.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.I1wxXd/Mural.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.paul-cossey.download.MURAL/downloads/MURAL.dmg/Mural.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.paul-cossey.download.MURAL/downloads/MURAL.dmg
Versioner: Found version 2.0.0 in file ~/Library/AutoPkg/Cache/com.github.paul-cossey.download.MURAL/downloads/MURAL.dmg/Mural.app/Contents/Info.plist
{'Output': {'version': '2.0.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.paul-cossey.download.MURAL/receipts/MURAL.download-receipt-20241227-185533.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.paul-cossey.download.MURAL/downloads/MURAL.dmg
```